### PR TITLE
Add +1 to levelup learnset pointer index

### DIFF
--- a/expansion/files.py
+++ b/expansion/files.py
@@ -443,7 +443,7 @@ class LevelUpLearnsetPointersH(HeaderFile):
         super().__init__(path)
 
     def appendData(self, species: str, prevMon: str):
-        idx = self.findLine(f'SPECIES_{prevMon.upper()}')
+        idx = self.findLine(f'SPECIES_{prevMon.upper()}') + 1
         idx = self._handleEndif(idx)
         self.insertBlankLine(idx)
         self.set_line(idx, f'    [SPECIES_{species.upper()}] = s{species.title()}LevelUpLearnset,\n')

--- a/vanilla/files.py
+++ b/vanilla/files.py
@@ -409,7 +409,7 @@ class LevelUpLearnsetPointersH(HeaderFile):
         super().__init__(path)
 
     def appendData(self, species: str, prevMon: str):
-        idx = self.findLine(f'SPECIES_{prevMon.upper()}')
+        idx = self.findLine(f'SPECIES_{prevMon.upper()}') + 1
         self.insertBlankLine(idx)
         self.set_line(idx, f'    [SPECIES_{species.upper()}] = s{species.title()}LevelUpLearnset,\n')
 


### PR DESCRIPTION
These lines didn't have a +1 like the other ones so the new levelup pointer would be added before the last species and not after.